### PR TITLE
Updating dependencies, adding two badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# test-with-files [![Build Status](https://secure.travis-ci.org/magnars/test-with-files.png)](http://travis-ci.org/magnars/test-with-files)
-[![Dependencies Status](https://jarkeeper.com/magnars/test-with-files/status.svg)](https://jarkeeper.com/magnars/test-with-files)
+# test-with-files [![Build Status](https://secure.travis-ci.org/magnars/test-with-files.png)](http://travis-ci.org/magnars/test-with-files) [![Dependencies Status](https://jarkeeper.com/magnars/test-with-files/status.svg)](https://jarkeeper.com/magnars/test-with-files)
 
 A Clojure library to easily write tests with files.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 A Clojure library to easily write tests with files.
 
-## Install
+## Installation
+
+Latest stable version:
+[![Clojars Project](https://img.shields.io/clojars/v/test-with-files.svg)](https://clojars.org/test-with-files)
 
 Add `test-with-files` to your `project.clj`, and include
 `test/resources` in the dev resource path:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# test-with-files [![Build Status](https://secure.travis-ci.org/magnars/test-with-files.png)](http://travis-ci.org/magnars/test-with-files) [![Dependencies Status](https://jarkeeper.com/magnars/test-with-files/status.svg)](https://jarkeeper.com/magnars/test-with-files)
+# test-with-files [![Build Status](https://secure.travis-ci.org/magnars/test-with-files.png)](http://travis-ci.org/magnars/test-with-files) [![Dependencies Status](https://jarkeeper.com/magnars/test-with-files/status.svg)](https://jarkeeper.com/magnars/test-with-files) [![Clojars Project](https://img.shields.io/clojars/v/test-with-files.svg)](https://clojars.org/test-with-files)
 
 A Clojure library to easily write tests with files.
 
 ## Installation
-
-Latest stable version:
-[![Clojars Project](https://img.shields.io/clojars/v/test-with-files.svg)](https://clojars.org/test-with-files)
 
 Add `test-with-files` to your `project.clj`, and include
 `test/resources` in the dev resource path:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # test-with-files [![Build Status](https://secure.travis-ci.org/magnars/test-with-files.png)](http://travis-ci.org/magnars/test-with-files)
+[![Dependencies Status](https://jarkeeper.com/magnars/test-with-files/status.svg)](https://jarkeeper.com/magnars/test-with-files)
 
 A Clojure library to easily write tests with files.
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/magnars/test-with-files"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-midje "3.0.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.2"]]
                    :resource-paths ["test/resources"]}})


### PR DESCRIPTION
- Updating the dependencies to current
- adding a Clojars badge for the latest stable version
- adding a Jarkeeper badge for if the dependencies are still current.
